### PR TITLE
Updating email list to data science hub

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -4,7 +4,7 @@
 
 * For help/questions, email our team of instructors/helpers: swc-dc-help@lists.wisc.edu
 * To join us as a helper/instructor in the future, send us an email to swc-dc@lists.wisc.edu, and/or join our mailing list by sending a blank email to join-swc-dc@lists.wisc.edu
-* Learn about future workshops and campus computing resources by joining the [Data Science Hub](http://datascience.wisc.edu/) email list.  To join send an email to [join-dshubcommunity@lists.wsic.edu](mailto:join-dshubcommunity@lists.wsic.edu) 
+* Learn about future workshops and campus computing resources by joining the [Data Science Hub](http://datascience.wisc.edu/) email list.  To join send an email to [join-dshubcommunity@lists.wisc.edu](mailto:join-dshubcommunity@lists.wisc.edu) 
 
 # Links and tutorials for independent learning
 

--- a/resources.md
+++ b/resources.md
@@ -4,7 +4,7 @@
 
 * For help/questions, email our team of instructors/helpers: swc-dc-help@lists.wisc.edu
 * To join us as a helper/instructor in the future, send us an email to swc-dc@lists.wisc.edu, and/or join our mailing list by sending a blank email to join-swc-dc@lists.wisc.edu
-* Learn about future workshops by [joining the ACI Mailing List](https://aci.wisc.edu/about/). 
+* Learn about future workshops and campus computing resources by joining the [Data Science Hub](http://datascience.wisc.edu/) email list.  To join send an email to [join-dshubcommunity@lists.wsic.edu](mailto:join-dshubcommunity@lists.wsic.edu) 
 
 # Links and tutorials for independent learning
 


### PR DESCRIPTION
@lmichael107 @ChristinaLK Do you think this looks okay?

Do you think I should also create a PR changing the ACI website section to Data Science Hub or removing it?
I'm conflicted because the ACI webpage is really great and has lots of info which isn't on the Data Science Hub website yet. However, I'm nervous about sending people there since it will eventually fall behind.