### PR TITLE
Add DoIT Application Design Review to resources

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -19,6 +19,7 @@
 * [UW Policy on Software (Intellectual Property) Ownership](https://www.wisconsin.edu/financial-administration/financial-administrative-policies-procedures/gapp-numeric-index/g10-computer-software-ownership/)
 * [Center for High Throughput Computing](http://chtc.cs.wisc.edu/) (when a program takes too long on your computer)
 * [Center for Open Science](https://cos.io/) and the [Open Science Framework](https://osf.io/)
+* [DoIT Application Design Review Brownbag Meetings](https://wiki.doit.wisc.edu/confluence/x/BVZQBQ)
 
 ## Shell
 * [Explain Shell](http://explainshell.com/)


### PR DESCRIPTION
I brought this up in the wrap-up of the last SWC workshop. @lmichael107 suggested maybe I make a pull request. After looking at their [web page](https://wiki.doit.wisc.edu/confluence/display/SOACOE/Application+Design+Review+Brownbags) again, this may not be a good resource for beginners. The site says:

> The meetings are open to all University of Wisconsin-Madison IT staff.

I've attended a couple of these and even presented at one about my SatPy python library. I don't think it is necessarily limited to "IT staff", but the talk topics do very widely from "Introduction to the features of Go" to "Better ways to present technical topics" to "How to use the PyCharm IDE". So they are programming topics, but maybe not beginner-level topics.

I leave it up to you guys to decide whether to close this or merge it. Took me 5 minutes to fork this, edit the file, and make a PR so no hard feelings if you close it.